### PR TITLE
feat: add option to show iframe url

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ url: (doc) => resolveProductionUrl(doc),
 // OR a string
 url: `https://sanity.io`,
 
+// Optional: Display the Url in the pane
+showDisplayUrl: true // boolean. default `true`.
+
 // Optional: Set the default size
 defaultSize: `mobile`, // default `desktop`
 

--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -35,6 +35,7 @@ export type IframeOptions = {
   url: string | ((document: SanityDocumentLike) => unknown)
   defaultSize?: 'desktop' | 'mobile'
   loader?: boolean | string
+  showDisplayUrl?: boolean
   reload: {
     revision: boolean | number
     button: boolean
@@ -58,7 +59,14 @@ const DEFAULT_SIZE = `desktop`
 
 function Iframe(props: IframeProps) {
   const {document: sanityDocument, options} = props
-  const {url, defaultSize = DEFAULT_SIZE, reload, loader, attributes = {}} = options
+  const {
+    url,
+    defaultSize = DEFAULT_SIZE,
+    reload,
+    loader,
+    attributes = {},
+    showDisplayUrl = true,
+  } = options
   const [displayUrl, setDisplayUrl] = useState(url && typeof url === 'string' ? url : ``)
   const [iframeSize, setIframeSize] = useState(sizes?.[defaultSize] ? defaultSize : DEFAULT_SIZE)
   const [loading, setLoading] = useState(false)
@@ -153,9 +161,11 @@ function Iframe(props: IframeProps) {
               />
             </Flex>
             <Box flex={1}>
-              <Text size={0} textOverflow="ellipsis">
-                {displayUrl}
-              </Text>
+              {showDisplayUrl && (
+                <Text size={0} textOverflow="ellipsis">
+                  {displayUrl}
+                </Text>
+              )}
             </Box>
             <Flex align="center" gap={1}>
               {reload?.button ? (


### PR DESCRIPTION
Adds option to hide iframe url as mentioned in https://github.com/sanity-io/sanity-plugin-iframe-pane/issues/21