### PR TITLE
fix: update minimum version of @sanity/ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sanity/icons": "^2.4.1",
         "@sanity/incompatible-plugin": "^1.0.0",
-        "@sanity/ui": "^1.0.0",
+        "@sanity/ui": "^1.1.0",
         "framer-motion": "^10.15.1",
         "usehooks-ts": "2.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@sanity/icons": "^2.4.1",
     "@sanity/incompatible-plugin": "^1.0.0",
-    "@sanity/ui": "^1.0.0",
+    "@sanity/ui": "^1.1.0",
     "framer-motion": "^10.15.1",
     "usehooks-ts": "2.9.1"
   },


### PR DESCRIPTION
The `@sanity/ui` dependency is not actually correct, as the codebase uses code from later versions than the one specified here, for instance `usePrefersReducedMotion`, which was not added until https://github.com/sanity-io/ui/releases/tag/v1.1.0.

This PR updates the minimum version to address that.