### PR TITLE
fix: `document` should never be `null`

### DIFF
--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -70,6 +70,7 @@ const MotionFlex = motion(Flex)
 
 export interface IframeProps {
   document: {
+    displayed: SanityDocument
     draft: SanityDocument | null
     published: SanityDocument | null
   }
@@ -78,7 +79,7 @@ export interface IframeProps {
 
 export function Iframe(props: IframeProps) {
   const {document, options} = props
-  const draft = document.draft || document.published
+  const draft = document.draft || document.published || document.displayed
 
   const {defaultSize = DEFAULT_SIZE, reload, attributes, showDisplayUrl = true, key} = options
 


### PR DESCRIPTION
Related to #90, should restore the behaviour in v2, but without losing the benefit in v3 in that it doesn't update values like `slug.current` until it's synced to Content Lake.