### PR TITLE
fix(deps): allow studio v4 in peer dep ranges + update main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,11 +102,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Semantic release
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           cache: npm
@@ -114,17 +123,7 @@ jobs:
       - run: npm ci
         # Branches that will release new versions are defined in .releaserc.json
       - run: npx semantic-release
-        # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state
-        # e.g. git tags were pushed but it exited before `npm publish`
-        if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        # Re-run semantic release with rich logs if it failed to publish for easier debugging
-      - run: npx semantic-release --dry-run --debug
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       },
       "peerDependencies": {
         "react": "^18.3 || ^19",
-        "sanity": "^3.74",
+        "sanity": "^3.74 || ^4.0.0-0",
         "styled-components": "^5.2 || ^6"
       }
     },
@@ -24219,21 +24219,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/sanity/node_modules/log-symbols/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/sanity/node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
     },
     "node_modules/sanity/node_modules/log-symbols/node_modules/has-flag": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "peerDependencies": {
     "react": "^18.3 || ^19",
-    "sanity": "^3.74",
+    "sanity": "^3.74 || ^4.0.0-0",
     "styled-components": "^5.2 || ^6"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```
Progress: resolved 1030, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ sanity-plugin-iframe-pane 3.2.1
  └── ✕ unmet peer sanity@^3.74: found 4.0.0-0
Done in 9s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally